### PR TITLE
Feat: breadcrumbs and header section

### DIFF
--- a/app/(portal)/(nexus)/products/page.tsx
+++ b/app/(portal)/(nexus)/products/page.tsx
@@ -1,11 +1,24 @@
 "use client";
 
-import { Typography } from "antd";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import HeaderSection from "@/components/HeaderSection";
+import { PlusOutlined, TagOutlined } from "@ant-design/icons";
 
 export default function ProductsPage() {
   return (
-    <section className="grid place-items-center h-full">
-      <Typography.Title>Products Page</Typography.Title>
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      <Breadcrumbs
+        items={[{ title: "Home", href: "/" }, { title: "Products" }]}
+      />
+
+      <HeaderSection
+        title="Products"
+        description="Manage your product catalog"
+        icon={<TagOutlined />}
+        onAddNew={() => {}}
+        buttonText="New Product"
+        buttonIcon={<PlusOutlined />}
+      />
     </section>
   );
 }

--- a/app/(portal)/(nexus)/suppliers/page.tsx
+++ b/app/(portal)/(nexus)/suppliers/page.tsx
@@ -7,6 +7,7 @@ import { Table, Button, message, Tag, Space, Divider, Breadcrumb } from "antd";
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
+  PlusOutlined,
   ShopOutlined,
 } from "@ant-design/icons";
 
@@ -215,7 +216,8 @@ export default function SuppliersPage() {
           setEditingSupplier(null);
           setIsModalOpen(true);
         }}
-        buttonText="+ New Supplier"
+        buttonText="New Supplier"
+        buttonIcon={<PlusOutlined />}
       />
 
       {/* Statistics */}

--- a/components/HeaderSection.tsx
+++ b/components/HeaderSection.tsx
@@ -8,12 +8,14 @@ const HeaderSection = ({
   icon,
   onAddNew,
   buttonText,
+  buttonIcon,
 }: {
   title: string;
   description?: string;
   icon: React.ReactNode;
   onAddNew: () => void;
   buttonText?: string;
+  buttonIcon?: React.ReactNode;
 }) => (
   <Space
     size="small"
@@ -51,8 +53,8 @@ const HeaderSection = ({
         )}
       </Space>
     </Space>
-    <Button type="primary" onClick={onAddNew}>
-      {buttonText || `+ New ${title}`}
+    <Button type="primary" onClick={onAddNew} icon={buttonIcon}>
+      {buttonText || `New ${title}`}
     </Button>
   </Space>
 );


### PR DESCRIPTION
## Backlog ID & Title
Backlog ID - 124 --> Product catalog

## Description
I added BreadCrumbs and HeaderSection to product page.

## Screenshots (Optional)
<img width="1470" alt="Screenshot 2568-06-24 at 2 57 54 PM" src="https://github.com/user-attachments/assets/cffb1297-2ef8-4bf3-a961-81e95fed51b5" />


## Type of Change
[x] ✨ New feature
[ ] 🐛 Bug fix
[ ] 🧹 Code cleanup/refactor
[ ] 📝 Documentation update
[ ] 🔧 Build/CI pipeline update
[ ] ⚠️ Breaking change